### PR TITLE
Fixes GPU build on Linux

### DIFF
--- a/R/xgb.dl.R
+++ b/R/xgb.dl.R
@@ -117,7 +117,7 @@ xgb.dl <- function(commit = "master",
     
     # Compile
     
-    cat(paste0("mkdir build && cd build", "\n"), file = xgb_git_file, append = TRUE)
+    cat(paste0("mkdir build", "\n"), file = xgb_git_file, append = TRUE)
     cat(paste0("cmake ..", ifelse(use_gpu == TRUE, " -DUSE_CUDA=ON", ""), ifelse(use_avx == TRUE, " -DUSE_AVX=ON", ""), " -DR_LIB=ON", "\n"), file = xgb_git_file, append = TRUE)
     cat(paste0("make install -j", "\n"), file = xgb_git_file, append = TRUE)
     


### PR DESCRIPTION
Was unnecessarily changing into build directory.

Fixes #1.